### PR TITLE
Genrate boilerplate methods with dataclass decorator

### DIFF
--- a/umlsparser/model/Concept.py
+++ b/umlsparser/model/Concept.py
@@ -1,8 +1,17 @@
 import collections
+from dataclasses import dataclass
 from typing import Set, Tuple, Dict
 
 
+@dataclass(init=False, repr=True, eq=True)
 class Concept:
+    __cui: str
+    __tui: str
+    __preferred_names: Dict[str, Set[str]]
+    __all_names: Dict[str, Set[str]]
+    __definitions: Set[Tuple[str, str]]
+    __source_ids: Dict[str, Set[str]]
+
     def __init__(self, cui: str):
         self.__cui = cui
         self.__tui = None

--- a/umlsparser/model/SemanticType.py
+++ b/umlsparser/model/SemanticType.py
@@ -1,18 +1,25 @@
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(init=False, repr=True, eq=True)
 class SemanticType:
+    """TUI (field UI of SRDEF)"""
+    __tui: str
+    """Type of SemanticType STY / RL (field RT of SRDEF)"""
+    __type: str
+    """Definition (field DEF or SRDEF)"""
+    __definition: str
+    """Name of SemanticType (field STY_RL of SRDEF)"""
+    __name: str
+
     def __init__(self, tui: str):
-        """TUI (field UI of SRDEF)"""
         self.__tui: str = tui
-
-        """Type of SemanticType STY / RL (field RT of SRDEF)"""
         self.__type: str = ''
-
-        """Definition (field DEF or SRDEF)"""
         self.__definition: str = ''
-
-        """Name of SemanticType (field STY_RL of SRDEF)"""
         self.__name: str = ''
 
-    def __add_srdef_data__(self, data: dict):
+    def __add_srdef_data__(self, data: Dict):
         self.__type = data.get('RT')
         self.__name = data.get('STY_RL')
         self.__definition = data.get('DEF')


### PR DESCRIPTION
This PR introduces the [dataclass](https://docs.python.org/3/library/dataclasses.html) decorator to the model classes. This is used to reduce boilerplate code for methods like repr.